### PR TITLE
Remove query preparation from frontend

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
   "name": "WikiSearchFront",
   "author": "Robis Koopmans",
-  "version": "2.0.5",
+  "version": "3.0.0",
   "url": "https://www.wikibase-solutions.com",
   "descriptionmsg": "wikisearchfront-desc",
   "license-name": "GPL-2.0-or-later",
@@ -14,7 +14,7 @@
   "requires": {
     "MediaWiki": ">= 1.27.0",
     "extensions": {
-      "WikiSearch": "*"
+      "WikiSearch": ">= 8.0.0"
     }
   },
   "ResourceModules": {

--- a/src/utilities/elastic.js
+++ b/src/utilities/elastic.js
@@ -1,8 +1,3 @@
-const insertWildcards = (term) => (term ? `*${term.split(' ')
-  .filter(e => e)
-  .reduce((a, b) => (/[^a-z_\-0-9]/i.test(a.slice(-1)) ? `${a} ${b}` : `${a}* *${b}`))
-  .replace(/\*+/g, '*')}*` : '*');
-
 const prepareQuery = (term) => {
   return term.trim();
 };

--- a/src/utilities/elastic.js
+++ b/src/utilities/elastic.js
@@ -4,17 +4,7 @@ const insertWildcards = (term) => (term ? `*${term.split(' ')
   .replace(/\*+/g, '*')}*` : '*');
 
 const prepareQuery = (term) => {
-  let searchTerm = term.trim();
-  if (searchTerm.length === 0) {
-    return '*';
-  }
-  searchTerm = searchTerm
-    .replace(/(:|\+|=|\/)/g, '\\$1');
-
-  return ['"', "'", 'AND', 'NOT', 'OR', '~', '(', ')', '?', '*', ' -']
-    .reduce((a, b) => a || searchTerm.indexOf(b) !== -1, false)
-    ? searchTerm
-    : insertWildcards(searchTerm);
+  return term.trim();
 };
 
 export default prepareQuery;


### PR DESCRIPTION
Since WikiSearch 8.0.0 (https://github.com/Open-CSP/WikiSearch/commit/b9a68234293eba327a7bf1366ebb8242a0694c92), it is no longer possible to disable query preparation in the backend, as this lead to many configuration issues. However, for this to work, the query should be sent as-is (raw) to the backend by the frontend.

This pull request removes query preparation from the frontend, and also improves the version constraint in the extension.json for WikiSearch (requiring 8.0.0 or higher).