### PR TITLE
Pass addModules an array argument

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
   "name": "WikiSearchFront",
   "author": "Robis Koopmans",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "url": "https://www.wikibase-solutions.com",
   "descriptionmsg": "wikisearchfront-desc",
   "license-name": "GPL-2.0-or-later",

--- a/includes/WikiSearchFrontHooks.php
+++ b/includes/WikiSearchFrontHooks.php
@@ -67,7 +67,7 @@ class WikiSearchFrontHooks {
 											   array(
 												   "config" => $searchConfig
 											   ) );
-		$parser->getOutput()->addModules( 'ext.WikiSearchFront.module' );
+∂		$parser->getOutput()->addModules( ['ext.WikiSearchFront.module'] );
 
 		$result = "<div id='app'></div>";
 


### PR DESCRIPTION
This fixes the following deprecation warning:

```
Deprecated
: Use of ParserOutput::addModules with non-array argument was deprecated in MediaWiki 1.38. [Called from WikiSearchFront\WikiSearchFrontHooks::onWikiSearchOnLoadFrontend in /var/www/html/extensions/WikiSearchFront/includes/WikiSearchFrontHooks.php at line 70] in
/var/www/html/includes/debug/MWDebug.php
on line
381
```