### PR TITLE
Update WikiSearchFrontHooks.php: replace deprecated addJsConfigVars

### DIFF
--- a/includes/WikiSearchFrontHooks.php
+++ b/includes/WikiSearchFrontHooks.php
@@ -63,10 +63,13 @@ class WikiSearchFrontHooks {
 			}
 		}
 
-		$parser->getOutput()->addJsConfigVars( "WikiSearchFront",
-											   array(
-												   "config" => $searchConfig
-											   ) );
+		if ( method_exists( \ParserOutput::class, 'setJsConfigVar' ) ) {
+			// MW 1.38+
+			$parser->getOutput()->setJsConfigVar( "WikiSearchFront", [ "config" => $searchConfig ] );
+		} else {
+			$parser->getOutput()->addJsConfigVars( "WikiSearchFront", [ "config" => $searchConfig ] );
+		}
+
 		$parser->getOutput()->addModules( ['ext.WikiSearchFront.module'] );
 
 		$result = "<div id='app'></div>";


### PR DESCRIPTION
Replace deprecated addJsConfigVars() for MW 1.38+. P.S. Needs to be revisited if sometime in the future, we want to allow for multiple interfaces on a single page. Maybe differentiate the keys or use appendJsConfigVar() with dedicated keys.